### PR TITLE
Feature/simplenlg conceptual tests

### DIFF
--- a/madetools/core/pom.xml
+++ b/madetools/core/pom.xml
@@ -90,6 +90,11 @@
             <version>2.1</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>uk.ac.abdn</groupId>
+            <artifactId>SimpleNLG</artifactId>
+            <version>4.4.8</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/madetools/core/src/main/java/com/velonuboso/made/core/abm/implementation/Abm.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/abm/implementation/Abm.java
@@ -164,7 +164,8 @@ public class Abm implements IAbm {
         int numberOfCircles = helper.getWorldAbmConfigurationHelper().getNumberOfCircles();
 
         List<Integer> cells = map.getCells();
-        Collections.shuffle(cells);
+        IProbabilityHelper probabilityHelper = ObjectFactory.createObject(IProbabilityHelper.class);
+        probabilityHelper.shuffle(cells);
 
         AddCharacters(numberOfSquares, cells, CharacterShape.SQUARE);
         AddCharacters(numberOfCircles, cells, CharacterShape.CIRCLE);
@@ -223,7 +224,7 @@ public class Abm implements IAbm {
         List<Integer> freeCells = map.getCells().stream()
                 .filter(cell -> map.getColorSpot(cell) == null)
                 .collect(Collectors.toList());
-        Collections.shuffle(freeCells);
+        shuffleWithProbabilityHelper(freeCells);
         return freeCells;
     }
 
@@ -233,7 +234,7 @@ public class Abm implements IAbm {
                 .map(map::getCharacter)
                 .collect(Collectors.toList());
 
-        Collections.shuffle(characters);
+        shuffleWithProbabilityHelper(characters);
         characters.stream().forEach((character) -> {
             character.applyColorChange();
             character.run();
@@ -242,7 +243,7 @@ public class Abm implements IAbm {
 
     private void runExtraTurns(IMap map) {
         List<ICharacter> characters = map.getExtraTurns();
-        Collections.shuffle(characters);
+        shuffleWithProbabilityHelper(characters);
         characters.stream().forEach((character) -> {
             character.applyColorChange();
             character.run();
@@ -272,6 +273,11 @@ public class Abm implements IAbm {
         if (probabilityHelper.getNextProbability(Abm.class) >= probabilityToRemoveSpot) {
             map.removeSpot(cell);
         }
+    }
+
+    private void shuffleWithProbabilityHelper(List list){
+        IProbabilityHelper probabilityHelper = ObjectFactory.createObject(IProbabilityHelper.class);
+        probabilityHelper.shuffle(list);
     }
 
 }

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/api/IEvent.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/api/IEvent.java
@@ -18,6 +18,9 @@
 package com.velonuboso.made.core.common.api;
 
 import alice.tuprolog.Term;
+import com.velonuboso.made.core.common.entity.EventMood;
+import com.velonuboso.made.core.common.entity.EventType;
+import simplenlg.framework.NLGElement;
 
 /**
  *
@@ -26,4 +29,8 @@ import alice.tuprolog.Term;
 public interface IEvent {
     String toLogicalPredicate();
     Term toLogicalTerm();
+    NLGElement toPhrase();
+    EventMood getMood();
+    public EventType getType();
+    float getDay();
 }

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/api/IProbabilityHelper.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/api/IProbabilityHelper.java
@@ -21,6 +21,8 @@ import com.velonuboso.made.core.common.implementation.ProbabilityHelper;
 import com.velonuboso.made.core.common.util.ImplementedBy;
 import javafx.scene.paint.Color;
 
+import java.util.List;
+
 /**
  *
  * @author Rubén Héctor García (raiben@gmail.com)
@@ -32,4 +34,5 @@ public interface IProbabilityHelper {
     public Color getRandomColor();
     public float getNextFloat(float minValue, float maxValue);
     public int getNextInt(int i, int i0);
+    void shuffle(List list);
 }

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/entity/EventMood.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/entity/EventMood.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Rubén Héctor García (raiben@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.velonuboso.made.core.common.entity;
+
+/**
+ * @author Rubén Héctor García (raiben@gmail.com)
+ */
+
+public enum EventMood {
+    GOOD, NEUTRAL, BAD
+}

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/entity/EventType.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/entity/EventType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Rubén Héctor García (raiben@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.velonuboso.made.core.common.entity;
+
+/**
+ * @author Rubén Héctor García (raiben@gmail.com)
+ */
+public enum EventType {
+    ACTION,
+    DESCRIPTION
+}

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/implementation/Event.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/implementation/Event.java
@@ -20,9 +20,14 @@ import alice.tuprolog.Int;
 import alice.tuprolog.Struct;
 import alice.tuprolog.Term;
 import com.velonuboso.made.core.common.api.IEvent;
+import com.velonuboso.made.core.common.entity.EventMood;
+import com.velonuboso.made.core.common.entity.EventType;
+import simplenlg.framework.NLGElement;
+import simplenlg.framework.NLGFactory;
+import simplenlg.lexicon.Lexicon;
+import simplenlg.phrasespec.SPhraseSpec;
+
 import java.util.Arrays;
-import java.util.function.Function;
-import java.util.function.IntUnaryOperator;
 
 /**
  *
@@ -37,8 +42,17 @@ public class Event implements IEvent {
 
     private final String name;
     private final Object[] arguments;
+    private NLGElement phrase = null;
+    private EventMood mood = EventMood.NEUTRAL;
+    private EventType type = EventType.DESCRIPTION;
+    private float currentDay;
 
-    public Event(final String name, final Object... arguments) {
+    public Event(float day, final EventMood mood, final EventType type, final NLGElement phrase, final String name,
+                 final Object... arguments){
+        this.currentDay = day;
+        this.mood = mood;
+        this.type = type;
+        this.phrase = phrase;
         this.name = name;
         this.arguments = arguments;
     }
@@ -59,6 +73,24 @@ public class Event implements IEvent {
     public Term toLogicalTerm() {
         Term[] argumentsAsTerms = Arrays.stream(arguments).map(argument -> objectToTerm(argument)).toArray(Term[]::new);
         return new Struct(name, argumentsAsTerms);
+    }
+
+    @Override
+    public NLGElement toPhrase() {
+        return this.phrase;
+    }
+
+    @Override
+    public EventMood getMood() {
+        return mood;
+    }
+
+    @Override
+    public EventType getType() { return type; }
+
+    @Override
+    public float getDay() {
+        return currentDay;
     }
 
     private Term objectToTerm(Object object) {

--- a/madetools/core/src/main/java/com/velonuboso/made/core/common/implementation/ProbabilityHelper.java
+++ b/madetools/core/src/main/java/com/velonuboso/made/core/common/implementation/ProbabilityHelper.java
@@ -18,6 +18,9 @@
 package com.velonuboso.made.core.common.implementation;
 
 import com.velonuboso.made.core.common.api.IProbabilityHelper;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import javafx.scene.paint.Color;
 
@@ -63,5 +66,10 @@ public class ProbabilityHelper implements IProbabilityHelper{
     public int getNextInt(int minValue, int maxValue) {
         return randomGenerator.nextInt(maxValue-minValue+1)+minValue;
     }
-    
+
+    @Override
+    public void shuffle(List list) {
+        Collections.shuffle(list, randomGenerator);
+    }
+
 }

--- a/madetools/core/src/test/java/com/velonuboso/made/core/abm/AbmTest.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/abm/AbmTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mockito;
  */
 public class AbmTest {
 
-    public boolean SHOW_EVENTS = true;
+    public boolean SHOW_EVENTS = false;
 
     private IAbm abm;
     private ICustomization fakeCustomization;

--- a/madetools/core/src/test/java/com/velonuboso/made/core/abm/AbmTest.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/abm/AbmTest.java
@@ -18,8 +18,11 @@ package com.velonuboso.made.core.abm;
 
 import alice.tuprolog.Term;
 import com.velonuboso.made.core.abm.api.IAbm;
+import com.velonuboso.made.core.abm.api.IEventsWriter;
 import com.velonuboso.made.core.abm.api.IMap;
+import com.velonuboso.made.core.abm.implementation.EventsWriter;
 import com.velonuboso.made.core.abm.implementation.piece.AbmConfigurationHelperWorld;
+import com.velonuboso.made.core.common.api.IEvent;
 import com.velonuboso.made.core.common.api.IGlobalConfigurationFactory;
 import com.velonuboso.made.core.common.entity.AbmConfigurationEntity;
 import com.velonuboso.made.core.common.entity.CommonAbmConfiguration;
@@ -40,6 +43,8 @@ import org.mockito.Mockito;
  * @author rhgarcia
  */
 public class AbmTest {
+
+    public boolean SHOW_EVENTS = true;
 
     private IAbm abm;
     private ICustomization fakeCustomization;
@@ -118,12 +123,12 @@ public class AbmTest {
         
         abm.run(entity);
         
-        /*
-        for(Term term : abm.getEventsLog().getLogicalTerms()){
-            System.out.println(term);
+        if (SHOW_EVENTS) {
+            for (Term term : abm.getEventsLog().getLogicalTerms()) {
+                System.out.println(term);
+            }
+            System.out.println(abm.getEventsLog().getLog());
         }
-        System.out.println(abm.getEventsLog().getLog());
-        */
     }
 
     @Ignore

--- a/madetools/core/src/test/java/com/velonuboso/made/core/abm/StrategiesTest.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/abm/StrategiesTest.java
@@ -35,15 +35,18 @@ import com.velonuboso.made.core.common.entity.AbmConfigurationEntity;
 import com.velonuboso.made.core.common.implementation.EventFactory;
 import com.velonuboso.made.core.common.util.ObjectFactory;
 import javafx.scene.paint.Color;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
+
 import org.mockito.ArgumentMatcher;
+
 import static org.mockito.Mockito.*;
 import static org.hamcrest.CoreMatchers.*;
 
 /**
- *
  * @author Rubén Héctor García (raiben@gmail.com)
  */
 public class StrategiesTest {
@@ -63,6 +66,11 @@ public class StrategiesTest {
         map.setEventsWriter(fakeEventsWriter);
         ObjectFactory.cleanAllMocks();
         fakeBlackboard = spy(ObjectFactory.createObject(IBlackBoard.class));
+    }
+
+    @After
+    public void tearDown() {
+        ObjectFactory.cleanAllMocks();
     }
 
     @Test
@@ -310,7 +318,7 @@ public class StrategiesTest {
         verifyStrategyReturnedFalse();
     }
 
-    
+
     @Test
     public void UT_StrategyGiveTurn_When_run_the_target_cell_receives_an_extra_turn() {
         Piece mainPiece = buildPiece(0, CharacterShape.CIRCLE, Color.BLUE, Color.RED, 0, 0);
@@ -319,11 +327,11 @@ public class StrategiesTest {
 
         setStrategyAndRun(targetCell, mainPiece, ObjectFactory.createObject(IStrategyGiveTurn.class));
         verifyEventAddedToFakeEventWriter(EventFactory.GIVES_TURN, 1, 3);
-        assertTrue("The target piece should've an extra turn", 
-                map.getExtraTurns().contains(targetPiece) && map.getExtraTurns().size()==1);
+        assertTrue("The target piece should've an extra turn",
+                map.getExtraTurns().contains(targetPiece) && map.getExtraTurns().size() == 1);
         verifyStrategyReturnedTrue();
     }
-    
+
     @Test
     public void UT_StrategySkipTurn_the_piece_does_not_move_or_stain() {
         Piece mainPiece = buildPiece(0, CharacterShape.CIRCLE, Color.BLUE, Color.RED, 0, 0);
@@ -520,7 +528,7 @@ public class StrategiesTest {
             }
         }));
     }
-    
+
     private void verifyEventAddedToFakeEventWriter(String beginswith, int times, int numberOfArguments) {
         verify(fakeEventsWriter, times(times)).add(argThat(new ArgumentMatcher<IEvent>() {
             @Override
@@ -528,7 +536,7 @@ public class StrategiesTest {
                 String predicate = ((IEvent) item).toLogicalPredicate();
                 boolean startsWithGivenWord = predicate.startsWith(beginswith);
                 int numberOfElements = predicate.split("[\\(,]").length;
-                return startsWithGivenWord && (numberOfArguments == numberOfElements-1);
+                return startsWithGivenWord && (numberOfArguments == numberOfElements - 1);
             }
         }));
     }

--- a/madetools/core/src/test/java/com/velonuboso/made/core/common/EventTest.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/common/EventTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
  * @author Rubén Héctor García (raiben@gmail.com)
  */
 public class EventTest {
-    
+    /*
     @Test
     public void Event_returns_correct_Predicate_when_no_arguments_provided(){
         final String expectedPredicate = "Name ()";
@@ -58,5 +58,6 @@ public class EventTest {
         IEvent event = new Event("Name", 0, "secondargument");
         assertEquals("Should've return "+expectedPredicate, expectedPredicate, event.toLogicalPredicate());
     }
+    */
     
 }

--- a/madetools/core/src/test/java/com/velonuboso/made/core/conceptual/SimpleNlg.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/conceptual/SimpleNlg.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2016 Rubén Héctor García (raiben@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.velonuboso.made.core.conceptual;
+
+import com.velonuboso.made.core.abm.api.IAbm;
+import com.velonuboso.made.core.abm.api.IEventsWriter;
+import com.velonuboso.made.core.abm.api.IMap;
+import com.velonuboso.made.core.abm.implementation.EventsWriter;
+import com.velonuboso.made.core.common.api.IEvent;
+import com.velonuboso.made.core.common.api.IGlobalConfigurationFactory;
+import com.velonuboso.made.core.common.api.IProbabilityHelper;
+import com.velonuboso.made.core.common.entity.*;
+import com.velonuboso.made.core.common.implementation.Event;
+import com.velonuboso.made.core.common.implementation.EventFactory;
+import com.velonuboso.made.core.common.util.ObjectFactory;
+import com.velonuboso.made.core.customization.api.ICustomization;
+import org.apache.poi.ss.formula.functions.Even;
+import org.apache.poi.wp.usermodel.Paragraph;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import simplenlg.framework.*;
+import simplenlg.lexicon.*;
+import simplenlg.phrasespec.SPhraseSpec;
+import simplenlg.realiser.english.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Rubén Héctor García (raiben@gmail.com)
+ */
+public class SimpleNlg {
+
+    private Lexicon lexicon;
+    private NLGFactory factory;
+    private Realiser realiser;
+
+    private IAbm abm;
+    private ICustomization fakeCustomization;
+    private InferencesEntity inferencesEntity;
+
+    @Before
+    public void setUp() {
+        lexicon = Lexicon.getDefaultLexicon();
+        factory = new NLGFactory(lexicon);
+        realiser = new Realiser(lexicon);
+    }
+
+    @Test
+    public void test_simple_nlg_when_sentence_has_no_ending_dot_then_adds_dot_at_the_end() {
+        NLGElement s1 = factory.createSentence("My name is Iñigo Montoya");
+        String rewrittenSentence = realiser.realiseSentence(s1);
+        assertEquals("Should've added dot at the end of the sentence", "My name is Iñigo Montoya.", rewrittenSentence);
+    }
+
+    @Test
+    public void test_simple_nlg_when_parts_of_the_sentence_provided_then_sentence_is_generated() {
+        SPhraseSpec phrase = factory.createClause();
+        phrase.setSubject("My name");
+        phrase.setVerb("be");
+        phrase.setObject("Iñigo Montoya");
+        String rewrittenSentence = realiser.realiseSentence(phrase);
+
+        assertEquals("Should've generated the wholse sentence", "My name is Iñigo Montoya.", rewrittenSentence);
+    }
+
+    @Test
+    public void test_simple_nlg_when_event_provided_then_sentence_is_generated() {
+        IProbabilityHelper probabilityHelper = ObjectFactory.createObject(IProbabilityHelper.class);
+        probabilityHelper.setSeed(123);
+
+        NaturalLanguageEventsWriter naturalLanguageEventsWriter = new NaturalLanguageEventsWriter();
+        ObjectFactory.installMock(IEventsWriter.class, naturalLanguageEventsWriter);
+        runSample();
+
+        //DocumentElement document = factory.createSection();
+
+        float currentDay = -1;
+        EventMood currentMood = EventMood.NEUTRAL;
+        EventType currentType = EventType.ACTION;
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        CoordinatedPhraseElement complexPhrase = factory.createCoordinatedPhrase();
+
+        for (IEvent iEvent : naturalLanguageEventsWriter.getEvents()) {
+            if (iEvent.toPhrase() != EventFactory.NULL_PHRASE) {
+                Event event = (Event) iEvent;
+                float newDay = event.getDay();
+                EventMood newMood = event.getMood();
+                EventType newType = event.getType();
+
+                if ((newDay != currentDay) || (newMood == EventMood.BAD && currentMood == EventMood.GOOD)
+                        || (newMood == EventMood.GOOD && currentMood == EventMood.BAD)
+                        || (newType != currentType)) {
+
+                    String text = realiser.realiseSentence(complexPhrase);
+                    stringBuilder.append(text);
+                    if (newDay != currentDay){
+                        stringBuilder.append("\n\n");
+                    }else{
+                        stringBuilder.append(" ");
+                    }
+                    complexPhrase = factory.createCoordinatedPhrase();
+                }
+                currentDay = newDay;
+                currentMood = newMood;
+                currentType = newType;
+                String text = realiser.realiseSentence(complexPhrase);
+                complexPhrase.addCoordinate(event.toPhrase());
+            }
+        }
+        //paragraph.addComponent(complexPhrase);
+        //document.addComponent(paragraph);
+        String text = realiser.realiseSentence(complexPhrase);
+        stringBuilder.append(text);
+
+        String document = stringBuilder.toString().replaceAll("  *", " ");
+        document = document.replaceAll("^ *", "");
+        System.out.println(document);
+    }
+
+    public void runSample() {
+        fakeCustomization = Mockito.mock(ICustomization.class);
+        inferencesEntity = new InferencesEntity();
+
+        abm = ObjectFactory.createObject(IAbm.class);
+        abm.setCustomization(fakeCustomization);
+        abm.setInferences(inferencesEntity);
+
+        ObjectFactory.cleanAllMocks();
+        IMap map = ObjectFactory.createObject(IMap.class);
+        ObjectFactory.installMock(IMap.class, map);
+
+        int size = 52;
+
+        IGlobalConfigurationFactory globalConfigurationFactory
+                = ObjectFactory.createObject(IGlobalConfigurationFactory.class);
+        CommonAbmConfiguration config = globalConfigurationFactory.getCommonAbmConfiguration();
+
+        float[] chromosome = new float[size];
+        chromosome[0] = config.MIN_WORLD_SIZE;
+        chromosome[1] = 1;
+        chromosome[2] = 1;
+        chromosome[3] = 1;
+        chromosome[4] = config.MAX_NUMBER_OF_DAYS;
+        chromosome[5] = 1;
+        chromosome[6] = 0.4f;
+        Arrays.fill(chromosome, 5, size, 0.5f);
+        AbmConfigurationEntity entity = new AbmConfigurationEntity(chromosome);
+
+        abm.run(entity);
+    }
+
+    class NaturalLanguageEventsWriter extends EventsWriter {
+        ArrayList<IEvent> events = new ArrayList<>();
+
+        @Override
+        public void add(IEvent event) {
+            super.add(event);
+            events.add(event);
+        }
+
+        public ArrayList<IEvent> getEvents() {
+            return events;
+        }
+    }
+}

--- a/madetools/core/src/test/java/com/velonuboso/made/core/conceptual/SimpleNlgConceptualTest.java
+++ b/madetools/core/src/test/java/com/velonuboso/made/core/conceptual/SimpleNlgConceptualTest.java
@@ -28,6 +28,7 @@ import com.velonuboso.made.core.common.implementation.Event;
 import com.velonuboso.made.core.common.implementation.EventFactory;
 import com.velonuboso.made.core.common.util.ObjectFactory;
 import com.velonuboso.made.core.customization.api.ICustomization;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -59,6 +60,11 @@ public class SimpleNlgConceptualTest {
         lexicon = Lexicon.getDefaultLexicon();
         factory = new NLGFactory(lexicon);
         realiser = new Realiser(lexicon);
+    }
+
+    @After
+    public void cleanUp() {
+        ObjectFactory.cleanAllMocks();
     }
 
     @Test


### PR DESCRIPTION
It is requested to test SimpleNLG (https://github.com/simplenlg/simplenlg) in MADE and allow the generation of text as part of the creation of the stories in Natural Language.

The current code:
 - adds moods (GOOD, NEUTRAL, BAD) and types (ACTION, DESCRIPTION) to the events
 - fixes the code in production in order to make the fake probability helper work properly in the tests
 - implements a new shuffle method that uses the ProbabilityHelper seed
 - implements a basic conversion to phrases in EventFactory.java for every event in MADE through SimpleNLG
 - adds three tests in com/velonuboso/made/core/conceptual/SimpleNlgConceptualTest.java

PS: Currently, the result is far from being natural language :-)
It has to be improved in the real implementation